### PR TITLE
fix: validating if base url is being defined when using http client service

### DIFF
--- a/src/internal/http/http-client.ts
+++ b/src/internal/http/http-client.ts
@@ -4,6 +4,15 @@ class HttpClientService {
     private readonly api: AxiosInstance;
 
     constructor(baseURL: string) {
+
+        if (!baseURL) {
+            const message = "Base url is not defined!";
+
+            console.log(message);
+
+            throw new Error(message);
+        }
+
         this.api = axios.create({
             baseURL
         });


### PR DESCRIPTION
- Pra evitar o uso do HttpClientService sem ter definido o base url no arquivo de env, jogaremos um erro